### PR TITLE
Modified the histogram maximum in function check_mos_area

### DIFF
--- a/mosaic/check_mos.C
+++ b/mosaic/check_mos.C
@@ -9,6 +9,16 @@ TString path = TString(Form("/eos/experiment/sndlhc/emulsionData/2022/emureco_Na
 // Change where to save the plots
 TString plotpath = TString(Form("/eos/user/s/snd2na/emu_reco_plots/RUN%i/b%06d", run, brick));
 
+Double_t getMeanEntries(TH2F *h2){
+	TH1I tmp("tmp", "tmp", 100, h2->GetMinimum(), h2->GetMaximum());
+  	for(int ux = 0; ux<h2->GetNbinsX();ux++){
+        	for(int uy = 0; uy<h2->GetNbinsY();uy++){
+                	tmp.Fill(h2->GetBinContent(ux, uy));
+        	}
+  	}
+	return tmp.GetMean();
+}
+
 void check_mos_side(int plate, int side) {
   TCut cside("cside",Form("s1.Side()==%d",side));
   TCut nocoin("nocoin","s2.eW>0");
@@ -61,6 +71,7 @@ void check_mos_area(int plate, int side) {
   }
 
   TCanvas *c = new TCanvas(Form("c_%i_%i", plate, side), Form("Mosaic plate %i side %i", plate, side), 800, 800);
+  h2->SetMaximum(getMeanEntries(h2)*2.8);
   h2->Draw("COLZ");
   c->Print(Form((plotpath+"/mosaic/mosaic_plate%i_%i.png"), plate, side));
 }


### PR DESCRIPTION
This change accounts for the histogram appearance in mosaic. In particular, the histogram z-axis is set to the average of the number of entries in every bin plus its 280% in order to try to show the structure of the map. Here showing the comparison between before and after of the histogram from the same data.

![Screenshot 2024-07-23 alle 15 19 57](https://github.com/user-attachments/assets/b550f86e-a26d-403b-8572-b5717a04ff04) *Histogram appearance without the fix*

![Screenshot 2024-07-23 alle 15 20 47](https://github.com/user-attachments/assets/7a0b503f-747f-4af9-a490-70b509af3342) *Histogram appearance after the fix, the structure is now more visible*
